### PR TITLE
Compute hash outside of critical sections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ json_schema = ["schemars"]
 ahash = "0.8"
 bstr = { version = "1.5", features = ["std"], default-features = false }
 byteorder = "1.5"
+hashbrown = "0.15"
 schemars = { version = "0.8", optional = true }
 serde = { version = "1", optional = true }
 static_assertions = "1.1"


### PR DESCRIPTION
This migrates from using std::collections::HashMap to hashbrown::HashTable, which allows us to compute the hash of our strings outside of a critical section, which was suggested in #3.